### PR TITLE
Corrects typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Include the library:
 
 Instantiate a geometry passing:
 <pre><code>var decalGeometry = new THREE.DecalGeometry(  
-    meshToIntersect, // it has to be a THREE.Geometry   
+    meshToIntersect, // it has to be a THREE.Mesh
     position, // THREE.Vector3 in world coordinates  
     direction, // THREE.Vector3 specifying the orientation of the decal  
     dimensions, // THREE.Vector3 specifying the size of the decal box  


### PR DESCRIPTION
I think there is a mistake in the README file, the DecalGeometry constructor's first argument must be an instance of THREE.Mesh, not of THREE.Geometry.

At first I try to use it with an instance of Geometry and it did not work until I use an instance of Mesh declared from the Geometry like that:

    var geometry = THREE.Geometry(...);
    var material = new THREE.MeshLambertMaterial(...);
    var mesh = new THREE.Mesh(geometry, material);
